### PR TITLE
Force the creation of the  syn0norm property after loading the model,…

### DIFF
--- a/w2v_server.py
+++ b/w2v_server.py
@@ -67,6 +67,7 @@ class Server(object):
     def __init__(self, fname):
         # load the word2vec model from gzipped file
         self.model = gensim.models.word2vec.Word2Vec.load_word2vec_format(fname, binary=True)
+        self.model.init_sims(replace=True)
         try:
             del self.model.syn0  # not needed => free up mem
             del self.model.syn1


### PR DESCRIPTION
Force the creation of the  syn0norm property after loading the model, with `self.model.init_sims(replace=True)`, making the code compatible with recent gensim version (2.1.0). 
This fix bugs like [this one ](https://stackoverflow.com/questions/44143441/code-for-gensim-word2vec-as-an-http-service-keyedvectors-attribute-error)